### PR TITLE
Adds isDistributedLocked() for global semantics + some other tweaks

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,4 +16,4 @@
 
 javac.source=1.5
 
-lib.version=0.1.4
+lib.version=0.1.5-rc0

--- a/build.xml
+++ b/build.xml
@@ -183,6 +183,33 @@ limitations under the License.
             <batchtest todir=".">
                 <fileset dir="${dir.build.java}">
                     <include name="**/*IntTests.class"/>
+                    <exclude name="**/FactoryIntTests.class"/>
+                </fileset>
+            </batchtest>
+        </junit>
+    </target>
+
+    <!-- ******************************************************************************* -->
+    <!-- Run the integration tests. Servers on 27017 and 27018 must be running to work.  -->
+    <!-- ******************************************************************************* -->
+
+    <target name="test-factory" depends="unit">
+
+        <junit fork="yes" haltonfailure="true">
+            <jvmarg value="-Duser.timezone=GMT"/>
+            <jvmarg value="-Dfile.encoding=UTF-8"/>
+            <classpath refid="classpath.all"/>
+
+            <classpath>
+                <pathelement path="${dir.build.java}"/>
+                <pathelement path="${dir.conf}"/>
+            </classpath>
+
+            <formatter type="brief" usefile="false"/>
+
+            <batchtest todir=".">
+                <fileset dir="${dir.build.java}">
+                    <include name="**/FactoryIntTests.class"/>
                 </fileset>
             </batchtest>
         </junit>

--- a/src/main/com/deftlabs/lock/mongo/DistributedLock.java
+++ b/src/main/com/deftlabs/lock/mongo/DistributedLock.java
@@ -28,9 +28,14 @@ import java.util.concurrent.locks.Lock;
 public interface DistributedLock extends Lock {
 
     /**
-     * Returns true if the lock is currently locked by the local process.
+     * Returns true if lock's held by this JVM / process.
      */
     public boolean isLocked();
+
+    /**
+     * Returns true if the lock is currently locked by any process.
+     */
+    public boolean isDistributedLocked();
 
     /**
      * Returns the lock name.

--- a/src/main/com/deftlabs/lock/mongo/DistributedLockSvc.java
+++ b/src/main/com/deftlabs/lock/mongo/DistributedLockSvc.java
@@ -53,5 +53,9 @@ public interface DistributedLockSvc {
      */
     public boolean isRunning();
 
+    /**
+     * Returns lock service options
+     */
+    public DistributedLockSvcOptions getSvcOptions();
 }
 

--- a/src/main/com/deftlabs/lock/mongo/DistributedLockSvcFactory.java
+++ b/src/main/com/deftlabs/lock/mongo/DistributedLockSvcFactory.java
@@ -17,6 +17,7 @@
 package com.deftlabs.lock.mongo;
 
 // Lib
+
 import com.deftlabs.lock.mongo.impl.SvcImpl;
 
 /**
@@ -25,29 +26,18 @@ import com.deftlabs.lock.mongo.impl.SvcImpl;
 public final class DistributedLockSvcFactory {
 
     public DistributedLockSvcFactory(final DistributedLockSvcOptions pOptions) {
-        _options = pOptions;
+        _options = pOptions.copy();
     }
 
     /**
-     * Returns the global lock service. This method also calls the startup method on the
-     * lock service returned (when it is created).
+     * Returns the lock service for the specific lock options if one exists.
+     * Otherwise if this is the first time these options have been seen, creates
+     * a new lock service implementation.
      */
     public DistributedLockSvc getLockSvc() {
-        if (_lockSvc != null && _lockSvc.isRunning()) return _lockSvc;
-
-        synchronized(_mutex) {
-            if (_lockSvc != null && _lockSvc.isRunning()) return _lockSvc;
-
-            final SvcImpl svc = new SvcImpl(_options);
-            svc.startup();
-            _lockSvc = svc;
-            return _lockSvc;
-        }
+        return SvcImpl.create(_options);
     }
 
-    private static volatile DistributedLockSvc _lockSvc = null;
-
     private final DistributedLockSvcOptions _options;
-    private final static Object _mutex = new Object();
 }
 

--- a/src/main/com/deftlabs/lock/mongo/DistributedLockSvcOptions.java
+++ b/src/main/com/deftlabs/lock/mongo/DistributedLockSvcOptions.java
@@ -107,6 +107,54 @@ public class DistributedLockSvcOptions {
     public void setHistoryCollectionName(final String pV) { _historyCollectionName = pV; }
     public String getHistoryCollectionName() { return _historyCollectionName; }
 
+    public DistributedLockSvcOptions copy() {
+        DistributedLockSvcOptions copy = new DistributedLockSvcOptions( _mongoUri, _dbName, _collectionName, _appName );
+
+        copy._historyCollectionName = this._historyCollectionName;
+        copy._hostname = this._hostname;
+        copy._hostAddress = this._hostAddress;
+        copy._enableHistory = this._enableHistory;
+        copy._historyIsCapped = this._historyIsCapped;
+        copy._historySize = this._historySize;
+
+        return copy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) return true;
+        if ( o == null || getClass() != o.getClass() ) return false;
+
+        DistributedLockSvcOptions that = (DistributedLockSvcOptions) o;
+
+        if ( _appName != null ? !_appName.equals( that._appName ) : that._appName != null ) return false;
+        if ( _collectionName != null ? !_collectionName.equals( that._collectionName ) : that._collectionName != null )
+            return false;
+        if ( _dbName != null ? !_dbName.equals( that._dbName ) : that._dbName != null ) return false;
+        if ( _mongoUri != null ? !_mongoUri.equals( that._mongoUri ) : that._mongoUri != null ) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = _mongoUri != null ? _mongoUri.hashCode() : 0;
+        result = 31 * result + ( _dbName != null ? _dbName.hashCode() : 0 );
+        result = 31 * result + ( _collectionName != null ? _collectionName.hashCode() : 0 );
+        result = 31 * result + ( _appName != null ? _appName.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DistributedLockSvcOptions{" +
+                "_collectionName='" + _collectionName + '\'' +
+                ", _appName='" + _appName + '\'' +
+                ", _dbName='" + _dbName + '\'' +
+                ", _mongoUri='" + _mongoUri + '\'' +
+                '}';
+    }
+
     private final String _mongoUri;
     private final String _dbName;
     private final String _collectionName;

--- a/src/test/com/deftlabs/lock/mongo/FactoryIntTests.java
+++ b/src/test/com/deftlabs/lock/mongo/FactoryIntTests.java
@@ -1,0 +1,46 @@
+package com.deftlabs.lock.mongo;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Tests service creation semantics. You must be running an instance of mongo on localhost:27017 and localhost:27018
+ */
+public final class FactoryIntTests {
+
+    private static final String MONGO_URI1 = "mongodb://127.0.0.1:27017/?maxpoolsize=10&waitqueuemultiple=5&connecttimeoutms=20000&sockettimeoutms=20000&autoconnectretry=true";
+    private static final String MONGO_URI2 = "mongodb://127.0.0.1:27018/?maxpoolsize=10&waitqueuemultiple=5&connecttimeoutms=20000&sockettimeoutms=20000&autoconnectretry=true";
+
+    @Test
+    public void factoryMaintainsSingleInstance() throws Exception {
+        final DistributedLockSvcOptions options1 = new DistributedLockSvcOptions(MONGO_URI1);
+        final DistributedLockSvc svc1 = new DistributedLockSvcFactory(options1).getLockSvc();
+
+        final DistributedLockSvcOptions options2 = new DistributedLockSvcOptions(MONGO_URI1);
+        final DistributedLockSvc svc2 = new DistributedLockSvcFactory(options2).getLockSvc();
+
+        assertSame(svc1, svc2);
+        assertEquals(svc1, svc2);
+    }
+
+    @Test public void canCreateSeparatelyConfiguredServices() throws Exception {
+        final DistributedLockSvcOptions options1 = new DistributedLockSvcOptions(MONGO_URI1);
+        final DistributedLockSvc svc1 = new DistributedLockSvcFactory(options1).getLockSvc();
+
+        final DistributedLockSvcOptions options2 = new DistributedLockSvcOptions(MONGO_URI2);
+        final DistributedLockSvc svc2 = new DistributedLockSvcFactory(options2).getLockSvc();
+
+        assertEquals(MONGO_URI1, svc1.getSvcOptions().getMongoUri());
+        assertEquals(MONGO_URI2, svc2.getSvcOptions().getMongoUri());
+    }
+
+    @Ignore
+    @Test(expected = IllegalArgumentException.class)
+    public void cannotRedefineMongoOptionsForSameHosts() throws Exception {
+        // TODO
+    }
+
+}


### PR DESCRIPTION
- Adding isDistributedLocked() for global semantics; if lock not held by current process then queries DB for lock status.
- Can now maintain distinct service instances for different service options.
- Setting background monitoring threads as daemons so they cannot prevent JVM shutdown.
- Overriding finalize as safety measure to ensure lock's cleaned up even if lock not explicitly destroyed before leaving scope.

Thanks Deft Labs!
