### PR TITLE
Fixes to service shutdown and monitor thread behavior

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -16,4 +16,4 @@
 
 javac.source=1.5
 
-lib.version=0.1.5
+lib.version=0.1.6

--- a/src/main/com/deftlabs/lock/mongo/DistributedLockSvcOptions.java
+++ b/src/main/com/deftlabs/lock/mongo/DistributedLockSvcOptions.java
@@ -102,6 +102,30 @@ public class DistributedLockSvcOptions {
     public String getHostAddress() { return _hostAddress; }
 
     /**
+     * Milliseconds between heartbeat checks.
+     */
+    public long getHeartbeatFrequency() { return _heartbeatFrequency; }
+    public void setHeartbeatFrequency(final long pHeartbeatFrequency) {
+        _heartbeatFrequency = pHeartbeatFrequency;
+    }
+
+    /**
+     * Milliseconds between lock timeout checks.
+     */
+    public long getTimeoutFrequency() { return _timeoutFrequency; }
+    public void setTimeoutFrequency(final long pTimeoutFrequency) {
+        _timeoutFrequency = pTimeoutFrequency;
+    }
+
+    /**
+     * Milliseconds between lock unlocked checks.
+     */
+    public long getLockUnlockedFrequency() { return _lockUnlockedFrequency; }
+    public void setLockUnlockedFrequency(final long pLockUnlockedFrequency) {
+        _lockUnlockedFrequency = pLockUnlockedFrequency;
+    }
+
+    /**
      * The default collection name is: lockHistory. Override here.
      */
     public void setHistoryCollectionName(final String pV) { _historyCollectionName = pV; }
@@ -122,5 +146,9 @@ public class DistributedLockSvcOptions {
     private boolean _enableHistory = true;
     private boolean _historyIsCapped = true;
     private long _historySize = 209715200;
+
+    private long _heartbeatFrequency = 5000;
+    private long _timeoutFrequency = 60000;
+    private long _lockUnlockedFrequency = 1000;
 }
 


### PR DESCRIPTION
Hi deftlabs!

This commit makes the following two changes:
- `SvcImpl.shutdown()` now closes the `Mongo` client and clears the `_locks` map; previously the starting and shutting down of multiple `SvcImpl` instances would leak the connections of the `Mongo` clients.
- The background monitor threads are now signaled to stop more gracefully before resorting to an interrupt. Previous approach of using interrupts first could potentially interrupt an in-process driver operation, causing the following log message: http://cl.ly/image/2X201k3m383l

Thanks!
